### PR TITLE
✨ Make map location handling smarter

### DIFF
--- a/src/js/actions.js
+++ b/src/js/actions.js
@@ -1,13 +1,31 @@
+export const ADD_TO_VISIBLE_LOCATIONS_STACK = "ADD_TO_VISIBLE_LOCATIONS_STACK";
 export const FLY_TO = "FLY_TO";
+export const REMOVE_FROM_VISIBLE_LOCATIONS_STACK =
+  "REMOVE_FROM_VISIBLE_LOCATIONS_STACK";
 export const SET_DATA_LAYER = "SET_DATA_LAYER";
 
 /*
  * Action creators
  */
+export function addToVisibleLocationsStack(visibleLocation) {
+  return { type: ADD_TO_VISIBLE_LOCATIONS_STACK, visibleLocation };
+}
+
+export function removeFromVisibleLocationsStack(visibleLocationId) {
+  return { type: REMOVE_FROM_VISIBLE_LOCATIONS_STACK, visibleLocationId };
+}
+
 export function flyTo(viewport) {
   return { type: FLY_TO, viewport };
 }
 
 export function setDataLayer(datalayer) {
   return { type: SET_DATA_LAYER, datalayer };
+}
+
+export class VisibleLocation {
+  constructor(id, viewport) {
+    this.id = id;
+    this.viewport = viewport;
+  }
 }

--- a/src/js/components/chapter.js
+++ b/src/js/components/chapter.js
@@ -6,19 +6,32 @@ import LocationWithVisibility from "./locationWithVisibility";
 import Region from "./region";
 import { Viewport } from "./map";
 
-import { flyTo } from "../actions";
+import {
+  addToVisibleLocationsStack,
+  removeFromVisibleLocationsStack,
+  VisibleLocation
+} from "../actions";
+
+const CHAPTER_LOCATION_ID = "chapter";
 
 class Chapter extends Component {
-  componentDidMount() {
-    this.props.flyTo(
-      new Viewport(
-        this.props.latitude,
-        this.props.longitude,
-        this.props.zoom,
-        this.props.bearing,
-        this.props.pitch
+  componentWillMount() {
+    this.props.addToVisibleLocationsStack(
+      new VisibleLocation(
+        CHAPTER_LOCATION_ID,
+        new Viewport(
+          this.props.latitude,
+          this.props.longitude,
+          this.props.zoom,
+          this.props.bearing,
+          this.props.pitch
+        )
       )
     );
+  }
+
+  componentWillUnmount() {
+    this.props.removeFromVisibleLocationsStack(CHAPTER_LOCATION_ID);
   }
 
   render() {
@@ -32,7 +45,11 @@ class Chapter extends Component {
         {this.props.regions.map((region, regionIndex) => (
           <Region title={region.title} key={regionIndex}>
             {region.locations.map((location, locationIndex) => (
-              <LocationWithVisibility key={locationIndex} {...location} />
+              <LocationWithVisibility
+                key={locationIndex}
+                regionTitle={region.title}
+                {...location}
+              />
             ))}
           </Region>
         ))}
@@ -43,5 +60,5 @@ class Chapter extends Component {
 
 export default connect(
   null,
-  { flyTo }
+  { addToVisibleLocationsStack, removeFromVisibleLocationsStack }
 )(Chapter);

--- a/src/js/components/home.js
+++ b/src/js/components/home.js
@@ -6,15 +6,28 @@ import Intro from "./intro";
 import { Viewport } from "./map";
 
 import { settings } from "../content";
-import { flyTo, setDataLayer } from "../actions";
+import {
+  addToVisibleLocationsStack,
+  removeFromVisibleLocationsStack,
+  setDataLayer,
+  VisibleLocation
+} from "../actions";
+
+const HOME_LOCATION_ID = "home";
 
 class Home extends Component {
   componentDidMount() {
-    this.props.flyTo(new Viewport(0, 0, 1, 0, 0));
+    this.props.addToVisibleLocationsStack(
+      new VisibleLocation(HOME_LOCATION_ID, new Viewport(0, 0, 1, 0, 0))
+    );
     this.props.setDataLayer({
       type: "fill",
       paint: { "fill-color": "#e58f52", "fill-opacity": 0.5 }
     });
+  }
+
+  componentWillUnmount() {
+    this.props.removeFromVisibleLocationsStack(HOME_LOCATION_ID);
   }
 
   render() {
@@ -39,5 +52,5 @@ class Home extends Component {
 
 export default connect(
   null,
-  { setDataLayer, flyTo }
+  { setDataLayer, addToVisibleLocationsStack, removeFromVisibleLocationsStack }
 )(Home);

--- a/src/js/components/locationWithVisibility.js
+++ b/src/js/components/locationWithVisibility.js
@@ -5,7 +5,11 @@ import VisibilitySensor from "react-visibility-sensor";
 import Location from "./location";
 import { Viewport } from "./map";
 
-import { flyTo } from "../actions";
+import {
+  addToVisibleLocationsStack,
+  removeFromVisibleLocationsStack,
+  VisibleLocation
+} from "../actions";
 
 class LocationWithVisibility extends Component {
   state = { isVisible: false };
@@ -15,25 +19,32 @@ class LocationWithVisibility extends Component {
       isVisible: isVisible
     }));
 
+    let visibleLocation = new VisibleLocation(
+      this.props.regionTitle + "-" + this.props.title,
+      new Viewport(
+        this.props.latitude,
+        this.props.longitude,
+        this.props.zoom,
+        this.props.bearing,
+        this.props.pitch
+      )
+    );
+
     if (isVisible) {
-      this.props.flyTo(
-        new Viewport(
-          this.props.latitude,
-          this.props.longitude,
-          this.props.zoom,
-          this.props.bearing,
-          this.props.pitch
-        )
-      );
+      this.props.addToVisibleLocationsStack(visibleLocation);
+    } else {
+      this.props.removeFromVisibleLocationsStack(visibleLocation.id);
     }
   };
+
+  componentWillUnmount;
 
   render() {
     return (
       <VisibilitySensor
         onChange={this.visibilityChange}
         partialVisibility={true}
-        minTopValue={100}
+        minTopValue={150}
       >
         <Location isVisible={this.state.isVisible} {...this.props} />
       </VisibilitySensor>
@@ -43,5 +54,5 @@ class LocationWithVisibility extends Component {
 
 export default connect(
   null,
-  { flyTo }
+  { addToVisibleLocationsStack, removeFromVisibleLocationsStack }
 )(LocationWithVisibility);

--- a/src/js/components/map.js
+++ b/src/js/components/map.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { easeCubic } from "d3-ease";
+import { isEqual, last } from "lodash";
 
 import MapGL, { FlyToInterpolator, Layer, Source } from "react-map-gl";
 
@@ -31,6 +32,18 @@ class Map extends Component {
     }));
   }
 
+  componentDidUpdate(prevProps, prevState, snapshot) {
+    if (
+      !isEqual(
+        prevProps.visibleLocationsStack,
+        this.props.visibleLocationsStack
+      )
+    ) {
+      let nextViewport = last(this.props.visibleLocationsStack).viewport;
+      this.props.flyTo(nextViewport);
+    }
+  }
+
   render() {
     return (
       <MapGL
@@ -58,6 +71,7 @@ class Map extends Component {
 
 const mapStateToProps = state => ({
   viewport: state.viewport,
+  visibleLocationsStack: state.visibleLocationsStack,
   datalayer: state.datalayer
 });
 

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -1,16 +1,37 @@
 import { createStore } from "redux";
 
-import { FLY_TO, SET_DATA_LAYER } from "./actions";
+import {
+  ADD_TO_VISIBLE_LOCATIONS_STACK,
+  FLY_TO,
+  REMOVE_FROM_VISIBLE_LOCATIONS_STACK,
+  SET_DATA_LAYER
+} from "./actions";
 
 import { Viewport } from "./components/map";
 
 const initialState = {
   viewport: new Viewport(41.221494, -75.40171, 12.5, 35, 40),
+  visibleLocationsStack: [],
   datalayer: null
 };
 
 function travelApp(state = initialState, action) {
   switch (action.type) {
+    case ADD_TO_VISIBLE_LOCATIONS_STACK:
+      return {
+        ...state,
+        visibleLocationsStack: [
+          ...state.visibleLocationsStack,
+          action.visibleLocation
+        ]
+      };
+    case REMOVE_FROM_VISIBLE_LOCATIONS_STACK:
+      return {
+        ...state,
+        visibleLocationsStack: state.visibleLocationsStack.filter(
+          visibleLocation => visibleLocation.id != action.visibleLocationId
+        )
+      };
     case FLY_TO:
       return { ...state, ...{ viewport: action.viewport } };
 


### PR DESCRIPTION
# Context
Map position depends on scroll and what elements are currently visible on screen. Every time a new element appeared on screen, map would fly there.

When there were more than one visible elements on screen with a position linked, it was possible to cause a few glitches scrolling back and forth where the final result was the map not showing the expected item.

Imagine this case:

### Steps to reproduce:
- User scrolls down until a block about Tokyo appears.
- As there is a visibility change, map will now show Tokyo.
- User keeps scrolling and a block about Kyoto appears. Part of Tokyo is still on screen.
- As there is a visibility change, map will now show Kyoto.
- User scrolls up. The block about Kyoto is no longer on screen

### What happens
- As no new element appeared, map remains on Kyoto.

### What should happen
- As the block about Kyoto is no longer visible and the one on Tokyo still is, the map should move back to Tokyo.

# Changes
Instead of only moving when something enters on screen, I added to the redux store the entire set of elements being displayed. The map component now will look at changes at this list, and always render the latest element that is still visible.